### PR TITLE
[fix] token 재발급 로직 layout 없는 page에서는 적용안되는 현상 fix

### DIFF
--- a/src/Routes/AuthRoute.tsx
+++ b/src/Routes/AuthRoute.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import Cookie from 'js-cookie';
 import { Navigate } from 'react-router-dom';
 import { IRouteProps } from 'types/Common';
+import { useSelector } from 'react-redux';
+import { RootState } from 'redux/store';
 
 function AuthRoute({ children }: IRouteProps) {
-  const accessToken = Cookie.get('accessToken');
+  const { accessToken } = useSelector((state: RootState) => state.auth);
   return accessToken ? <Navigate to="/" /> : <>{children}</>;
 }
 

--- a/src/Routes/PrivateRoute.tsx
+++ b/src/Routes/PrivateRoute.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { IRouteProps } from 'types/Common';
-import Cookie from 'js-cookie';
+import { useSelector } from 'react-redux';
+import { RootState } from 'redux/store';
 
 function PrivateRoute({ children }: IRouteProps) {
-  const accessToken = Cookie.get('accessToken');
+  const { accessToken } = useSelector((state: RootState) => state.auth);
   return !accessToken ? (
     <Navigate to="/signin" replace={true} />
   ) : (

--- a/src/Routes/Router.tsx
+++ b/src/Routes/Router.tsx
@@ -28,7 +28,14 @@ function Router() {
     <BrowserRouter>
       <ScrollToTop />
       <Routes>
-        <Route path="/signup" element={<SignUp />} />
+        <Route
+          path="/signup"
+          element={
+            <AuthRoute>
+              <SignUp />
+            </AuthRoute>
+          }
+        />
         <Route
           path="/signin/member"
           element={
@@ -78,7 +85,14 @@ function Router() {
           }
         />
         <Route path="/comment/:commentId" element={<CommentDetail />} />
-        <Route path="/confirm/write" element={<ConfirmWrite />} />
+        <Route
+          path="/confirm/write"
+          element={
+            <PrivateRoute>
+              <ConfirmWrite />
+            </PrivateRoute>
+          }
+        />
 
         <Route element={<Layout />}>
           <Route path="/search" element={<Search />} />

--- a/src/Routes/Router.tsx
+++ b/src/Routes/Router.tsx
@@ -20,8 +20,10 @@ import ScrollToTop from 'components/Common/ScrollToTop';
 import ConfirmWrite from 'page/confirm/ConfirmWrite';
 import AuthRoute from './AuthRoute';
 import PrivateRoute from './PrivateRoute';
+import useAuthRefresh from 'hooks/useAuthRefresh';
 
 function Router() {
+  useAuthRefresh();
   return (
     <BrowserRouter>
       <ScrollToTop />

--- a/src/components/Common/Layout.tsx
+++ b/src/components/Common/Layout.tsx
@@ -5,11 +5,10 @@ import styled from 'styled-components';
 import { Outlet, useLocation } from 'react-router-dom';
 import { Link } from 'react-router-dom';
 import useDetailNavigation from 'hooks/useDetailNavigation';
-import { useSelector } from 'react-redux';
-import { RootState } from 'redux/store';
+import useGetToken from 'hooks/useGetToken';
 
 function Layout() {
-  const { accessToken } = useSelector((state: RootState) => state.auth);
+  const accessToken = useGetToken();
   const { pathNavigation } = useDetailNavigation('signin');
   const onClickLogIn = () => {
     pathNavigation();

--- a/src/components/Common/Layout.tsx
+++ b/src/components/Common/Layout.tsx
@@ -5,15 +5,16 @@ import styled from 'styled-components';
 import { Outlet, useLocation } from 'react-router-dom';
 import { Link } from 'react-router-dom';
 import useDetailNavigation from 'hooks/useDetailNavigation';
-import useAuthRefresh from 'hooks/useAuthRefresh';
+import { useSelector } from 'react-redux';
+import { RootState } from 'redux/store';
 
 function Layout() {
+  const { accessToken } = useSelector((state: RootState) => state.auth);
   const { pathNavigation } = useDetailNavigation('signin');
   const onClickLogIn = () => {
     pathNavigation();
   };
 
-  const accessToken = useAuthRefresh();
   const location = useLocation();
   return (
     <>

--- a/src/hooks/useAuthRedirect.ts
+++ b/src/hooks/useAuthRedirect.ts
@@ -1,11 +1,12 @@
-import Cookie from 'js-cookie';
+import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
+import { RootState } from 'redux/store';
 
 export default function useAuthRedirect() {
   const navigation = useNavigate();
+  const { accessToken } = useSelector((state: RootState) => state.auth);
 
   const checkAuthAndProceed = (callback: () => void) => {
-    const accessToken = Cookie.get('accessToken');
     if (!accessToken) {
       navigation('/signin');
     } else {
@@ -14,7 +15,6 @@ export default function useAuthRedirect() {
   };
 
   const redirectTo = (path: string) => {
-    const accessToken = Cookie.get('accessToken');
     if (!accessToken) {
       navigation('/signin');
     } else {

--- a/src/hooks/useGetToken.ts
+++ b/src/hooks/useGetToken.ts
@@ -1,0 +1,8 @@
+import { useSelector } from 'react-redux';
+import { RootState } from 'redux/store';
+
+export default function useGetToken() {
+  const { accessToken } = useSelector((state: RootState) => state.auth);
+
+  return accessToken;
+}

--- a/src/redux/reducer/auth.ts
+++ b/src/redux/reducer/auth.ts
@@ -5,12 +5,14 @@ export interface IAuthState {
   authDone: boolean;
   authError: string | null;
   authLoading: boolean;
+  accessToken: string | null;
 }
 
 const initialState: IAuthState = {
   authDone: false,
   authError: null,
   authLoading: false,
+  accessToken: null,
 };
 
 const authSlice = createSlice({
@@ -19,6 +21,12 @@ const authSlice = createSlice({
   reducers: {
     resetAuthDone: (state) => {
       state.authDone = false;
+    },
+    setToken: (state, action) => {
+      state.accessToken = action.payload;
+    },
+    removeToken: (state) => {
+      state.accessToken = null;
     },
   },
   extraReducers: (builder) => {
@@ -47,6 +55,7 @@ const authSlice = createSlice({
         state.authLoading = false;
         state.authDone = true;
         state.authError = null;
+        state.accessToken = action.payload.data.token;
       })
       .addCase(authLoginByEmail.rejected, (state, action) => {
         state.authLoading = false;
@@ -56,5 +65,5 @@ const authSlice = createSlice({
   },
 });
 
-export const { resetAuthDone } = authSlice.actions;
+export const { resetAuthDone, setToken, removeToken } = authSlice.actions;
 export default authSlice;


### PR DESCRIPTION
+ login accessToken 전역으로 관리하도록 변경
+ useGetToken hook 구현
+ 기존 cookie 에서 accessToken 을 가져다 쓰던 로직들 store token을 이용하도록 변경
+ AuthRouter , PrivateRouter 적용 안된 page 적용